### PR TITLE
removing the addition of 'from dual' to certain queries

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -301,11 +301,17 @@ func (node *Select) Format(buf *TrackedBuffer) {
 		buf.Myprintf(" ")
 	}
 
-	buf.Myprintf("select %v%s%s%s%v from %v%v%v%v%v%v%s",
-		node.Comments, node.Cache, node.Distinct, node.Hints, node.SelectExprs,
-		node.From, node.Where,
-		node.GroupBy, node.Having, node.OrderBy,
-		node.Limit, node.Lock)
+	if len(node.From) == 0 {
+		buf.Myprintf("select %v%s%s%s%v",
+			node.Comments, node.Cache, node.Distinct, node.Hints, node.SelectExprs)
+	} else {
+
+		buf.Myprintf("select %v%s%s%s%v from %v%v%v%v%v%v%s",
+			node.Comments, node.Cache, node.Distinct, node.Hints, node.SelectExprs,
+			node.From, node.Where,
+			node.GroupBy, node.Having, node.OrderBy,
+			node.Limit, node.Lock)
+	}
 }
 
 func (node *Select) walkSubtree(visit Visit) error {

--- a/parse_test.go
+++ b/parse_test.go
@@ -29,7 +29,7 @@ var (
 		output string
 	}{{
 		input:  "select 1",
-		output: "select 1 from dual",
+		output: "select 1",
 	}, {
 		input: "select 1 from t",
 	}, {
@@ -525,13 +525,13 @@ var (
 	}, {
 		input: "select /* interval keyword */ adddate('2008-01-02', interval 1 year) from t",
 	}, {
-		input: "select /* dual */ 1 from dual",
+		input: "select /* dual */ 1",
 	}, {
-		input:  "select /* Dual */ 1 from Dual",
-		output: "select /* Dual */ 1 from dual",
+		input:  "select /* Dual */ 1",
+		output: "select /* Dual */ 1",
 	}, {
-		input:  "select /* DUAL */ 1 from Dual",
-		output: "select /* DUAL */ 1 from dual",
+		input:  "select /* DUAL */ 1",
+		output: "select /* DUAL */ 1",
 	}, {
 		input: "select /* column as bool in where */ a from t where b",
 	}, {
@@ -564,7 +564,7 @@ var (
 		input:  "select /*!401011 from*/ t",
 		output: "select 1 from t",
 	}, {
-		input: "select /* dual */ 1 from dual",
+		input: "select /* dual */ 1",
 	}, {
 		input: "insert /* simple */ into a values (1)",
 	}, {
@@ -1233,8 +1233,8 @@ var (
 		input:  "select k collate 'latin1_german2_ci' as k1 from t1 order by k1 asc",
 		output: "select k collate latin1_german2_ci as k1 from t1 order by k1 asc",
 	}, {
-		input:  "select /* drop trailing semicolon */ 1 from dual;",
-		output: "select /* drop trailing semicolon */ 1 from dual",
+		input:  "select /* drop trailing semicolon */ 1;",
+		output: "select /* drop trailing semicolon */ 1",
 	}, {
 		input: "select /* cache directive */ sql_no_cache 'foo' from t",
 	}, {
@@ -1261,7 +1261,7 @@ var (
 	}, {
 		input: "select e.id, s.city from employees as e join stores partition (p1) as s on e.store_id = s.id",
 	}, {
-		input: "select truncate(120.3333, 2) from dual",
+		input: "select truncate(120.3333, 2)",
 	}, {
 		input: "update t partition (p0) set a = 1",
 	}, {
@@ -1440,7 +1440,7 @@ func TestKeywords(t *testing.T) {
 		output string
 	}{{
 		input:  "select current_timestamp",
-		output: "select current_timestamp() from dual",
+		output: "select current_timestamp()",
 	}, {
 		input: "update t set a = current_timestamp()",
 	}, {
@@ -1456,7 +1456,7 @@ func TestKeywords(t *testing.T) {
 		output: "update t set b = utc_timestamp() + 5",
 	}, {
 		input:  "select utc_time, utc_date",
-		output: "select utc_time(), utc_date() from dual",
+		output: "select utc_time(), utc_date()",
 	}, {
 		input:  "select 1 from dual where localtime > utc_time",
 		output: "select 1 from dual where localtime() > utc_time()",

--- a/sql.go
+++ b/sql.go
@@ -5047,7 +5047,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 //line sql.y:1765
 		{
-			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: TableName{Name: NewTableIdent("dual")}}}
+			yyVAL.tableExprs = nil
 		}
 	case 321:
 		yyDollar = yyS[yypt-2 : yypt+1]

--- a/sql.y
+++ b/sql.y
@@ -1763,7 +1763,7 @@ col_alias:
 
 from_opt:
   {
-    $$ = TableExprs{&AliasedTableExpr{Expr:TableName{Name: NewTableIdent("dual")}}}
+    $$ = nil
   }
 | FROM table_references
   {


### PR DESCRIPTION
found this from here https://github.com/ClearBlade/sqlparser/pull/3/commits/45b184119ca9a278c1e475b1b6d0e69afb861c77

if you do something like SELECT CONNECTION_ID() then when we run through our sqlite parser it returns something like SELECT CONNECTION_ID() from dual. the 'from dual' part is throwing off sqlite and causing issues